### PR TITLE
Updateable model fields

### DIFF
--- a/lib/services.identity.js
+++ b/lib/services.identity.js
@@ -669,37 +669,9 @@ function updateIdentity(req, res, next) {
       brIdentity.setRoles(req.user.identity, identity, callback);
     }],
     update: ['updateRoles', function(callback, results) {
-      var identity = {id: results.getId};
-
-      // conditional values only set if preset
-      if(req.body.description) {
-        identity.description = req.body.description;
-      }
-      if(req.body.email) {
-        identity.email = req.body.email;
-      }
-      if(req.body.image) {
-        identity.image = req.body.image;
-      }
-      if(req.body.label) {
-        identity.label = req.body.label;
-      }
-      if(req.body.sysGravatarType) {
-        identity.sysGravatarType = req.body.sysGravatarType;
-      }
-      if(req.body.sysImageType) {
-        identity.sysImageType = req.body.sysImageType;
-      }
-      if(req.body.sysPublic) {
-        identity.sysPublic = req.body.sysPublic;
-      }
-      if(req.body.sysSigningKey) {
-        identity.sysSigningKey = req.body.sysSigningKey;
-      }
-      if(req.body.url) {
-        identity.url = req.body.url;
-      }
-
+      var identity = {};
+      identity = constructIdentity(req.body, config.identity.fields);
+      identity.id = results.getId;
       // FIXME: allow changes to identity type?
       /*
       //identity.type = req.body.type;
@@ -712,6 +684,19 @@ function updateIdentity(req, res, next) {
     }
     res.sendStatus(204);
   });
+}
+
+function constructIdentity(fromIdentity, fields) {
+  var constructedIdentity = {identity: {}};
+  var fromIdentity = {identity: fromIdentity};
+  for(var i = 0; i < fields.length; ++i) {
+    var field = fields[i];
+    var value = _.get(fromIdentity, field, null);
+    if(value) {
+      _.set(constructedIdentity, field, value);
+    }
+  }
+  return constructedIdentity.identity;
 }
 
 // static passcode character set

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "bedrock": "^1.0.6",
     "bedrock-docs": "^2.0.0",
-    "bedrock-identity": "^4.1.0",
+    "bedrock-identity": "^4.2.0",
     "bedrock-key": "^3.0.0",
     "bedrock-mail": "^2.0.0",
     "bedrock-mongodb": "^2.0.0",

--- a/tests/001-service.js
+++ b/tests/001-service.js
@@ -128,7 +128,7 @@ describe('identity-service', function() {
       });
     });
 
-    it.only('should return 409 on a duplicate identity', function(done) {
+    it('should return 409 on a duplicate identity', function(done) {
       var userId = uuid.v4();
       var privateKeyPem =
         config['identity-rest'].test.users.admin.keys.privateKey.privateKeyPem;


### PR DESCRIPTION
Dependent on this PR https://github.com/digitalbazaar/bedrock-identity/pull/11

The only place we actually do input validation on identities is through updates -- I think it's a little weird that it was set up that way, what were some of the reasons for that? Anyway, this basically just moves the allowable update fields to the config instead of hardcoding them into the request handler, making them extensible by other modules that want to allow other fields if they chose to do so.
